### PR TITLE
Allow options to be a builder function

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,40 @@ export default defineConfig((env) => ({
 }));
 ```
 
+```js
+// vite.config.js - using plugin-legacy, and generating a stats file
+// for the the modern and legacy outputs
+import { defineConfig } from 'vite';
+import legacy from '@vitejs/plugin-legacy';
+import { webpackStats } from 'rollup-plugin-webpack-stats';
+
+export default defineConfig((env) => ({
+  build: {
+    rollupOptions: {
+      output: {
+        plugins: [
+          // Output webpack-stats-modern.json file for the modern build
+          // Output webpack-stats-legacy.json file for the legacy build
+          // Stats are an output plugin, as plugin-legacy works by injecting
+          // an addtional output, which duplicates the plugins configured here
+          statsPlugin((options) => {
+            const isLegacy = options.format === 'system';
+            return {
+              fileName: `webpack-stats${isLegacy ? '-legacy' : '-modern'}.json`,
+            };
+          }),
+        ],
+      },
+    },
+  },
+  plugins: [
+    legacy({
+      /* Your legacy config here */
+    }),
+  ],
+}));
+```
+
 ### Options
 
 - `fileName` - JSON stats file inside rollup/vite output directory

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ export default defineConfig((env) => ({
           // Output webpack-stats-modern.json file for the modern build
           // Output webpack-stats-legacy.json file for the legacy build
           // Stats are an output plugin, as plugin-legacy works by injecting
-          // an addtional output, which duplicates the plugins configured here
-          statsPlugin((options) => {
+          // an additional output, that duplicates the plugins configured here
+          webpackStats((options) => {
             const isLegacy = options.format === 'system';
             return {
               fileName: `webpack-stats${isLegacy ? '-legacy' : '-modern'}.json`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'rollup';
+import { Plugin, OutputOptions } from 'rollup';
 
 import { BundleTransformOptions, bundleToWebpackStats } from './transform';
 
@@ -14,14 +14,22 @@ interface WebpackStatsOptions extends BundleTransformOptions {
   fileName?: string;
 }
 
-export const webpackStats = (options: WebpackStatsOptions = {}): Plugin => ({
+type WebpackStatsOptionsOrBuilder =
+  | WebpackStatsOptions
+  | ((outputOptions: OutputOptions) => WebpackStatsOptions);
+
+export const webpackStats = (
+  options: WebpackStatsOptionsOrBuilder = {}
+): Plugin => ({
   name: NAME,
-  generateBundle(_, bundle) {
-    const output = bundleToWebpackStats(bundle, options);
+  generateBundle(outputOptions, bundle) {
+    const resolvedOptions =
+      typeof options === 'function' ? options(outputOptions) : options;
+    const output = bundleToWebpackStats(bundle, resolvedOptions);
 
     this.emitFile({
       type: 'asset',
-      fileName: options?.fileName || 'webpack-stats.json',
+      fileName: resolvedOptions.fileName || 'webpack-stats.json',
       source: JSON.stringify(output),
     });
   },

--- a/test/package/package.test.js
+++ b/test/package/package.test.js
@@ -4,11 +4,19 @@ import { rollup } from 'rollup';
 import rollupConfig from './rollup.config';
 
 describe('package test', () => {
-  test('should output bundle stats JSON file', async () => {
-    const bundle = await rollup(rollupConfig);
-    const res = await bundle.generate({ });
+  test('should output bundle stats JSON file when options is an object', async () => {
+    const bundle = await rollup(rollupConfig[0]);
+    const res = await bundle.generate(rollupConfig[0].output);
     expect(res.output[1]).toMatchObject({
-      fileName: 'webpack-stats.json'
+      fileName: 'webpack-stats.json',
+    });
+  });
+
+  test('should output bundle stats JSON file when options is a builder function', async () => {
+    const bundle = await rollup(rollupConfig[1]);
+    const res = await bundle.generate(rollupConfig[1].output);
+    expect(res.output[1]).toMatchObject({
+      fileName: 'stats-dist2.json',
     });
   });
 });

--- a/test/package/rollup.config.js
+++ b/test/package/rollup.config.js
@@ -1,12 +1,26 @@
 const path = require('path');
 const { webpackStats } = require('rollup-plugin-webpack-stats');
 
-module.exports = {
-  input: path.join(__dirname, 'src/index.js'),
-  output: {
-    dir: path.join(__dirname, 'dist'),
+module.exports = [
+  {
+    input: path.join(__dirname, 'src/index.js'),
+    output: {
+      dir: 'dist',
+    },
+    plugins: [webpackStats()],
   },
-  plugins: [
-    webpackStats(),
-  ],
-};
+  {
+    input: path.join(__dirname, 'src/index.js'),
+    output: {
+      dir: 'dist2',
+    },
+    plugins: [
+      // A contrived demo to show that options can access outputOptions
+      webpackStats((outputOptions) => {
+        return {
+          fileName: `stats-${outputOptions.dir}.json`,
+        };
+      }),
+    ],
+  },
+];


### PR DESCRIPTION
By allowing the plugin options to be a function that has access to the output options, we can generate unique configurations on a per-output basis.

This is particularly important when integrating with Vite's plugin-legacy to enable creating distinct stats files for the legacy and modern outputs.


### But why allow access to `outputOptions`?

I'm using Vite and [`@vite/plugin-legacy`](https://www.npmjs.com/package/@vitejs/plugin-legacy) to create modern and legacy output in a single build. I'd like to use `rollup-plugin-webpack-stats` stats for both the modern and legacy bundles.

How `@vite/plugin-legacy` works is by essentially adding [a new rollup output](https://github.com/vitejs/vite/blob/147e9228bb1c75db153873761eb7a120a2bd09a4/packages/plugin-legacy/src/index.ts#L426-L438) that uses `format: 'system'` to your existing build, copying the plugins and other options of any existing outputs.

By making the options be a function that can use the current output's options, I can add `webpackStats` to my Vite config like so, using the contents of the output options to infer if I'm producing legacy or modern outputs:

```js
// vite.config.js - using plugin-legacy, and generating a stats file
// for the the modern and legacy outputs
import { defineConfig } from 'vite';
import legacy from '@vitejs/plugin-legacy';
import { webpackStats } from 'rollup-plugin-webpack-stats';

export default defineConfig((env) => ({
  build: {
    rollupOptions: {
      output: {
        plugins: [
          // Output webpack-stats-modern.json file for the modern build
          // Output webpack-stats-legacy.json file for the legacy build
          // Stats are an output plugin, as plugin-legacy works by injecting
          // an addtional output, which duplicates the plugins configured here
           statsPlugin((outputOptions) => {
            const isLegacy = outputOptions.format === 'system';
            return {
              fileName: `webpack-stats${isLegacy ? '-legacy' : '-modern'}.json`,
            };
          }),
        ],
      },
    },
  },
  plugins: [
    legacy({
      /* Your legacy config here */
    }),
  ],
}));
```

This ability to expose the outputOptions is inspired by [`rollup-plugin-visualizer`](https://github.com/btd/rollup-plugin-visualizer/blob/dec839823db43af6b34d54779ed1db0486fe4e1c/plugin/index.ts#L130)