### PR TITLE
Add identifier to module

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -19,6 +19,7 @@ export interface WebpackStatsFilteredChunk {
 }
 
 export interface WebpackStatsFilteredModule {
+  identifier: string;
   name: string;
   size?: number;
   chunks: Array<string | number>;
@@ -129,6 +130,7 @@ export const bundleToWebpackStats = (
           moduleEntry.chunks.push(chunkId);
         } else {
           moduleByFileName[relativeModulePathWithPrefix] = {
+            identifier: relativeModulePathWithPrefix,
             name: relativeModulePathWithPrefix,
             size: options.moduleOriginalSize
               ? moduleInfo.originalLength

--- a/test/unit/transform.test.ts
+++ b/test/unit/transform.test.ts
@@ -231,6 +231,10 @@ describe('bundleToWebpackStats', () => {
       modules: [
         {
           chunks: ['e1c35b4'],
+          identifier: `.${path.sep}${path.join(
+            'src',
+            'component-a.js',
+          )}`,
           name: `.${path.sep}${path.join(
             'src',
             'component-a.js',
@@ -239,6 +243,10 @@ describe('bundleToWebpackStats', () => {
         },
         {
           chunks: ['e1c35b4'],
+          identifier: `.${path.sep}${path.join(
+            'src',
+            'index.js'
+          )}`,
           name: `.${path.sep}${path.join(
             'src',
             'index.js'
@@ -247,6 +255,11 @@ describe('bundleToWebpackStats', () => {
         },
         {
           chunks: ['95848fd'],
+          identifier: `.${path.sep}${path.join(
+            'node_modules',
+            'package-a',
+            'index.js'
+          )}`,
           name: `.${path.sep}${path.join(
             'node_modules',
             'package-a',
@@ -256,6 +269,11 @@ describe('bundleToWebpackStats', () => {
         },
         {
           chunks: ['95848fd'],
+          identifier: `.${path.sep}${path.join(
+            'node_modules',
+            'package-b',
+            'index.js'
+          )}`,
           name: `.${path.sep}${path.join(
             'node_modules',
             'package-b',
@@ -265,6 +283,12 @@ describe('bundleToWebpackStats', () => {
         },
         {
           chunks: ['e7b195f'],
+          identifier: `.${path.sep}${path.join(
+            'src',
+            'components',
+            'component-b',
+            'index.js',
+          )}`,
           name: `.${path.sep}${path.join(
             'src',
             'components',
@@ -275,6 +299,12 @@ describe('bundleToWebpackStats', () => {
         },
         {
           chunks: ['7cd4868'],
+          identifier: `.${path.sep}${path.join(
+            'src',
+            'components',
+            'component-c',
+            'index.js',
+          )}`,
           name: `.${path.sep}${path.join(
             'src',
             'components',


### PR DESCRIPTION
The content of the generated stats file is incomplete compared to output produced by webpack, I suspect this because the subset of fields used by bundle-stats are present and it didn't make sense to add many more.

Bundle-stats is great, though my team are somewhat used to using [Statoscope](https://github.com/statoscope/statoscope) as an alternative mechanism for analysing webpack stats files.

Unfortunatly it seems that the stats file generated by `rollup-plugin-webpack-stats` fails to render a report within statoscope as it is missing an `identifier` field on the module objects.  Adding this field fixes the error, and allows the statoscope report to render.