### PR TITLE
feat: add bundle parameter to transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ export default defineConfig((env) => ({
 - `fileName` - JSON stats file inside rollup/vite output directory
 - `excludeAssets` - exclude matching assets: `string | RegExp | ((filepath: string) => boolean) | Array<string | RegExp | ((filepath: string) => boolean)>`
 - `excludeModules` - exclude matching modules: `string | RegExp | ((filepath: string) => boolean) | Array<string | RegExp | ((filepath: string) => boolean)>`
-- `transform` - access and mutate the resulting stats after the conversion: `(stats: WebpackStatsFilterd) => WebpackStatsFilterd`
+- `transform` - access and mutate the resulting stats after the conversion: `(stats: WebpackStatsFilterd, bundle: OutputBundle) => WebpackStatsFilterd`
 
 ### Examples
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -59,7 +59,7 @@ export type BundleTransformOptions = {
   /**
    * Transform function to access and mutate the resulting stats after the convertion
    */
-  transform?: (stats: WebpackStatsFiltered) => WebpackStatsFiltered;
+  transform?: (stats: WebpackStatsFiltered, bundle: OutputBundle) => WebpackStatsFiltered;
 };
 
 export const bundleToWebpackStats = (
@@ -159,7 +159,7 @@ export const bundleToWebpackStats = (
   let result: WebpackStatsFiltered;
 
   try {
-    result = options.transform(stats);
+    result = options.transform(stats, bundle);
   } catch (error) {
     console.error('Custom transform failed! Returning stats without any transforms.', error);
     result = stats;

--- a/test/unit/transform.test.ts
+++ b/test/unit/transform.test.ts
@@ -310,7 +310,7 @@ describe('bundleToWebpackStats', () => {
 
   test('transforms rollup bundle stats to webpack stats using custom transformer', () => {
     expect(bundleToWebpackStats(statsWithDynamicEntry, { 
-      transform: (stats) => {
+      transform: (stats, bundle) => {
         const mainChunkIndex = stats.chunks?.findIndex((chunk) => chunk.names?.includes("main"));
 
         if (typeof mainChunkIndex !== 'undefined' && stats?.chunks?.[mainChunkIndex]) {
@@ -319,6 +319,9 @@ describe('bundleToWebpackStats', () => {
             initial: true,
           };
         }
+
+        // Adding arbitary info to the stats object to prove that we have access to bundle
+        (stats as typeof stats & {moduleCount: number}).moduleCount = Object.keys(bundle).length;
 
         return stats;
       },
@@ -337,7 +340,8 @@ describe('bundleToWebpackStats', () => {
           names: ['main'],
           files: ['assets/main-abcd1234.js'],
         },
-      ]
+      ],
+      moduleCount: 1
     });
   });
 });


### PR DESCRIPTION
Alternative to #258.

Expose rollup's `OutputBundle` in the transform to allow for arbitrary extensions of the stats object.

This allows for transforms based upon the content of the OutputBundle in addition to data already in the stats object.

For instance in https://github.com/relative-ci/rollup-plugin-webpack-stats/pull/258#issuecomment-2448705673 I talked about the idea of exposing `reasons` on the modules object - which is part of webpack's stats.json content but is not consumed by bundle-stats.