### PR TITLE
perf: use `Buffer.byteLength` in `getByteSize`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ export function getByteSize(content?: string | Uint8Array<ArrayBufferLike>): num
   }
 
   if (typeof content === 'string') {
-    return Buffer.from(content).length;
+    return Buffer.byteLength(content);
   }
 
   return content?.length || 0;


### PR DESCRIPTION
`Buffer.from(str).length` will allocate the buffer and that will be collected by GC. It would be more performant to use `Buffer.byteLength` that can avoid the large allocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the accuracy of byte size calculation for string content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->