### PR TITLE
upgrade rollup plugin stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
-        "rollup-plugin-stats": "1.4.2"
+        "rollup-plugin-stats": "1.5.0"
       },
       "devDependencies": {
         "@release-it/conventional-changelog": "10.0.1",
@@ -4641,9 +4641,9 @@
       }
     },
     "node_modules/rollup-plugin-stats": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-stats/-/rollup-plugin-stats-1.4.2.tgz",
-      "integrity": "sha512-xxWDwKDklJ2tMm+U4ZwRxtmx5laC9Dj/4uhnkNsj0MQdMEHvdbcaVjW96ew+n3U9scnmhqimX/CekuKxLfPe5A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-stats/-/rollup-plugin-stats-1.5.0.tgz",
+      "integrity": "sha512-TsWaV7ulwPA9JhqGJemrDJkvXNeNQb60lB13gIcT2kVDXlBM/PQD3GqVyhCJpvn43Y4YT5+VmWDRsbIAbuilBA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "vitest": "3.2.4"
   },
   "dependencies": {
-    "rollup-plugin-stats": "1.4.2"
+    "rollup-plugin-stats": "1.5.0"
   },
   "peerDependencies": {
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -18,7 +18,7 @@ type WebpackStatsOptions = {
    * @default - fs.write(FILENAME, JSON.stringify(STATS, null, 2));
    */
   write?: StatsWrite;
-} & Omit<StatsOptions, "source"> & BundleTransformOptions;
+} & Omit<StatsOptions, "source" | "map"> & BundleTransformOptions;
 
 type WebpackStatsOptionsOrBuilder =
   | WebpackStatsOptions


### PR DESCRIPTION
- **chore: Update rollup-plugin-stats to v1.5.0**
- **fix: Plugin - omit rollup-plugin-stats map option**
