### PR TITLE
fix plugin import

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "prebuild": "rimraf ./dist",
-    "build": "rollup -c rollup.config.mjs",
+    "build": "tsc && rollup -c rollup.config.mjs",
     "lint": "exit 0",
     "test:unit": "vitest test/unit",
     "test:package": "cd test/package && vitest",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,7 +3,7 @@ import extractStats, { type StatsOptions } from 'rollup-plugin-stats/extract';
 
 import { type BundleTransformOptions, bundleToWebpackStats } from './transform';
 import { type StatsWrite, statsWrite } from './write';
-import { formatFileSize, resolveFilepath } from './utils';
+import { formatFileSize, getByteSize, resolveFilepath } from './utils';
 
 const PLUGIN_NAME = 'webpackStats';
 


### PR DESCRIPTION
- **build: Run tsc before build**
- **fix: Plugin - import getByteSize**

---

- resolves: https://github.com/relative-ci/rollup-plugin-webpack-stats/issues/590


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The plugin now displays the size of the generated stats file in a human-readable format after each build.
* **Chores**
  * Updated the build process to compile TypeScript before bundling, ensuring up-to-date output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->