### PR TITLE
`types` must come first in export conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     },
     "./transform": {
+      "types": "./build/transform.d.ts",
       "import": "./dist/transform.mjs",
-      "require": "./dist/transform.cjs",
-      "types": "./build/transform.d.ts"
+      "require": "./dist/transform.cjs"
     }
   },
   "author": {


### PR DESCRIPTION
Per https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing

> The "types" condition should always come first in "exports".


When `types` is at the bottom of the object, projects using `moduleResolution:"node16"` can not find the types for the package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added official TypeScript type definitions to the package exports for both the primary module and the transform entry. This improves editor IntelliSense, autocompletion, and compile-time type safety without affecting runtime behavior or import paths. Consumers using TypeScript or modern editors now get richer typings out of the box and better DX.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->