### PR TITLE
Add exports=named to rollup output config

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,6 +14,7 @@ export default defineConfig([
     output: {
       dir: OUTPUT_DIR,
       format: 'esm',
+      exports: 'named',
       entryFileNames: '[name].mjs',
       chunkFileNames: 'chunks/[name].mjs',
       sourcemap: true,
@@ -26,6 +27,7 @@ export default defineConfig([
     output: {
       dir: OUTPUT_DIR,
       format: 'commonjs',
+      exports: 'named',
       entryFileNames: '[name].cjs',
       chunkFileNames: 'chunks/[name].cjs',
       sourcemap: true,


### PR DESCRIPTION
Currently index.ts contains a single default export, and as `output.exports` is not specified it uses the value of "default". This causes problems with generating CommonJS output that is meant to be interchangeable with ESM output as detailed in https://rollupjs.org/configuration-options/#output-exports and https://www.typescriptlang.org/docs/handbook/modules/appendices/esm-cjs-interop.html. This also causes problems with typescript's `moduleResolution:node16` option as the types types published by this package do match the commonjs output.

Prior to this change the types in `index.d.ts` are `import { webpackStats } from './plugin'; export default webpackStats;` which is correct for the esm build output.

The compiled `index.cjs` file however contains `module.exports = webpackStats;`. The correct types for this this content would be `export = webpackStats`.


---

To make the commonjs output match the types that are generated, and have commonjs and esm behave equivalently, this PR adds `exports: "named"` to the rollup output options.

This has no effect on the esm output, but changes the commonjs output in index.cjs file as follows:

```diff
- module.exports = webpackStats;
+ exports.default = webpackStats;
``` 

---

This is a breaking change, as it means commonjs consumers will have to change how they consume the package:

```diff
- const webpackStatsPlugin = require('rollup-plugin-webpack-stats');
+ const webpackStatsPlugin = require('rollup-plugin-webpack-stats').default
```

---

My general approach to working around this problem is "I only ever use named exports, I totally avoid `export default`", so personally I'd also change `export default webpackStats` to `export {webpackStats}` but I figure this is a less invasive change.