### PR TITLE
build: Enable oidc publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,5 +136,4 @@ jobs:
 
       - run: npm run release
         env:
-          NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,5 +137,4 @@ jobs:
       - run: npm run release
         env:
           NPM_CONFIG_PROVENANCE: true
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config/release-it/branch.js
+++ b/config/release-it/branch.js
@@ -1,10 +1,9 @@
-const config = require('./common');
+import commonConfig from './common';
 
-module.exports = {
-  ...config,
+export default {
+  ...commonConfig,
   git: {
-    ...config.git,
-    // eslint-disable-next-line no-template-curly-in-string
+    ...commonConfig.git,
     commitMessage: 'DROP - release ${version}'
   }
 };

--- a/config/release-it/common.js
+++ b/config/release-it/common.js
@@ -14,7 +14,8 @@ module.exports = {
   npm: {
     publish: false,
     ignoreVersion: true,
-    allowSameVersion: true
+    allowSameVersion: true,
+    skipChecks: true
   },
   github: {
     draft: false,

--- a/config/release-it/common.js
+++ b/config/release-it/common.js
@@ -1,14 +1,10 @@
-require('dotenv').config();
-
-module.exports = {
+export default {
   git: {
     commit: true,
-    // eslint-disable-next-line no-template-curly-in-string
     commitMessage: ':package: release ${version}\n[ci skip]',
     push: true,
     requireUpstream: false,
     tag: true,
-    // eslint-disable-next-line no-template-curly-in-string
     tagName: 'v${version}'
   },
   npm: {

--- a/config/release-it/master.js
+++ b/config/release-it/master.js
@@ -1,18 +1,17 @@
-const config = require('./common');
+import commonConfig from './common';
 
-module.exports = {
-  ...config,
+export default {
+  ...commonConfig,
   git: {
-    ...config.git,
-    // eslint-disable-next-line no-template-curly-in-string
+    ...commonConfig.git,
     commitMessage: ':package: release ${version}'
   },
   github: {
-    ...config.github,
+    ...commonConfig.github,
     release: true
   },
   plugins: {
-    ...config.plugins,
+    ...commonConfig.plugins,
     '@release-it/conventional-changelog': {
       preset: 'angular'
     }

--- a/config/release-it/release.js
+++ b/config/release-it/release.js
@@ -1,9 +1,9 @@
-const config = require('./common');
+import commonConfig from './common';
 
-module.exports = {
-  ...config,
+export default {
+  ...commonConfig,
   git: {
-    ...config.git,
+    ...commonConfig.git,
     commit: false,
     push: false,
     tag: false,
@@ -11,7 +11,7 @@ module.exports = {
     requireUpstream: false
   },
   npm: {
-    ...config.npm,
+    ...commonConfig.npm,
     publish: true
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@rollup/plugin-typescript": "12.1.4",
         "@tsconfig/node18": "18.2.4",
         "@types/node": "24.3.0",
-        "dotenv": "17.2.1",
         "husky": "9.1.7",
         "memfs": "4.36.3",
         "release-it": "19.0.4",
@@ -2623,19 +2622,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -4977,7 +4963,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@rollup/plugin-typescript": "12.1.4",
     "@tsconfig/node18": "18.2.4",
     "@types/node": "24.3.0",
-    "dotenv": "17.2.1",
     "husky": "9.1.7",
     "memfs": "4.36.3",
     "release-it": "19.0.4",

--- a/scripts/setup-registry.sh
+++ b/scripts/setup-registry.sh
@@ -8,4 +8,4 @@ sleep 10
 npm config set registry=http://localhost:4873
 npm config set //localhost:4873/:_authToken=fooBar # Add a non empty token for npm 6
 
-npm publish
+npm publish --tag beta


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - CI release now uses GitHub token only; NPM token and provenance vars removed.
  - Packages are published under the beta tag by default.
  - Removed dotenv from devDependencies.
  - Streamlined npm release checks (skipChecks enabled).

- Refactor
  - Release configuration migrated to ES module style and consolidated around a shared config; no runtime impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->