### PR TITLE
fix: Set rolldown as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,10 +88,13 @@
     "rolldown": "^1.0.0-beta.0"
   },
   "peerDependenciesMeta": {
-    "vite": {
+    "rolldown": {
       "optional": true
     },
     "rollup": {
+      "optional": true
+    },
+    "vite": {
       "optional": true
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated package metadata to include Rolldown as an optional peer dependency and normalized the ordering of peer dependency metadata. Vite and Rollup remain optional. This change may reduce peer warning noise in package managers but does not affect behavior, builds, or APIs. No user-facing features are added or removed today.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->